### PR TITLE
Feature/debugging improvements

### DIFF
--- a/src/state.rs
+++ b/src/state.rs
@@ -59,12 +59,13 @@ where
 // =====================
 
 pub trait StateTypes {
-    type In;
-    type Out;
+    type In: Debug;
+    type Out: Debug;
     type Err: Debug;
 }
 
-pub enum DeliveryStatus<U, E: Debug> {
+#[derive(Debug)]
+pub enum DeliveryStatus<U: Debug, E: Debug> {
     Delivered,
     Unexpected(U),
     Error(E),
@@ -76,6 +77,16 @@ pub enum Transition<Types: StateTypes> {
     Same,
     Next(BoxedState<Types>),
     Terminal,
+}
+
+impl<Types: StateTypes + 'static> Debug for Transition<Types> {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter) -> Result<(), std::fmt::Error> {
+        match self {
+            Transition::Same => write!(formatter, "Same"),
+            Transition::Next(state) => write!(formatter, "Next: <{}>", state.desc()),
+            Transition::Terminal => write!(formatter, "Terminal"),
+        }
+    }
 }
 
 #[cfg(test)]
@@ -91,6 +102,7 @@ mod test {
     }
 
     #[allow(dead_code)]
+    #[derive(Debug)]
     enum Incoming {
         P1,
         P2(()),

--- a/src/state_machine.rs
+++ b/src/state_machine.rs
@@ -107,7 +107,11 @@ where
         feed: mpsc::UnboundedReceiver<Types::In>,
         on_initialization: mpsc::UnboundedSender<Vec<Types::Out>>,
     ) -> Self {
-        log::debug!("[{}] State machine has been initialized", id);
+        log::debug!(
+            "[{}] State machine has been initialized at <{}>",
+            id,
+            initial_state.desc()
+        );
 
         Self {
             id,
@@ -236,7 +240,7 @@ impl<Types: StateTypes + 'static> InnerState<Types> {
     /// If successful returns OK(()), other wise Err(messages).
     fn try_initialize(&mut self, id: &str) -> Result<(), Vec<Types::Out>> {
         if !self.is_initialized {
-            log::debug!("[{}] Initializing", id);
+            log::debug!("[{}] Initializing <{}>", id, self.inner.desc());
 
             let messages = self.inner.initialize();
 

--- a/src/state_machine.rs
+++ b/src/state_machine.rs
@@ -320,6 +320,7 @@ mod test {
         type Err = String;
     }
 
+    #[derive(Debug)]
     enum Message {
         PlaceOrder,
         Damage,
@@ -328,6 +329,7 @@ mod test {
         Cancel,
     }
 
+    #[derive(Debug)]
     enum Verify {
         Address,
         PaymentDetails,


### PR DESCRIPTION
This PR will make it possible to include the method return types in tracing instrumentation using `#[instrument(ret)]`, by implementing `Debug` on the return types.